### PR TITLE
Update main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ define(function (require, exports, module) {
     "use strict";
     var LanguageManager = brackets.getModule("language/LanguageManager");
 
-    LanguageManager.defineLanguage("go", {
+    LanguageManager.defineLanguage("fortran", {
         name: "Fortran",
         mode: "fortran",
         fileExtensions: ["f", "for", "f90", "f95", "f03", "f15"],


### PR DESCRIPTION
Corrected LanguageManager.defineLanguage argument: Changed "go" to "fortran". This edit allows the plugin to properly register in the Brackets language manager.